### PR TITLE
商品削除

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -37,10 +37,13 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    if @item.destroy
+    unless current_user.id == @item.user_id
       redirect_to root_path
-    else
-      render :show
+      if @item.destroy
+        redirect_to root_path
+      else
+        render :show
+      end
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
-  before_action :set_item, only: [:edit, :show, :update]
+  before_action :set_item, only: [:edit, :show, :update, :destroy]
   def index
     @items = Item.all.order(id: 'ASC')
   end
@@ -33,6 +33,14 @@ class ItemsController < ApplicationController
       redirect_to item_path
     else
       render :edit
+    end
+  end
+
+  def destroy
+    if @item.destroy
+      redirect_to root_path
+    else
+      render :show
     end
   end
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -28,7 +28,7 @@
       <% if current_user.id == @item.user_id %>
       <%= link_to '商品の編集', edit_item_path, method: :get, class: "item-red-btn" %>
       <p class='or-text'>or</p>
-      <%= link_to '削除', item_path, method: :delete, class:'item-destroy' %>
+      <%= link_to '削除あ', item_path, method: :delete, class:'item-destroy' %>
       <% elsif  @item.present? %>
       <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
       <% end %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -28,7 +28,7 @@
       <% if current_user.id == @item.user_id %>
       <%= link_to '商品の編集', edit_item_path, method: :get, class: "item-red-btn" %>
       <p class='or-text'>or</p>
-      <%= link_to '削除あ', item_path, method: :delete, class:'item-destroy' %>
+      <%= link_to '削除', item_path, method: :delete, class:'item-destroy' %>
       <% elsif  @item.present? %>
       <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
       <% end %>


### PR DESCRIPTION
WHAT
商品削除機能の実装
WHY
商品を出品したユーザーが削除できるようにするため

前の段階で削除機能を間違って記述してしまったのでプルリクエストがわかるように　『削除あ』　にしまいした

https://gyazo.com/1dd8ec6787ec628102f2b2a244b431e2